### PR TITLE
defer error for 1 second, will only show if neuroglancer actually fails.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,11 @@
   <link rel="mask-icon" href="images/favicon/safari-pinned-tab.svg?v=rMJJ5wk4zj" color="#5bbad5">
   <link rel="shortcut icon" href="images/favicon/favicon.ico?v=rMJJ5wk4zj">
   <script src="https://unpkg.com/vue/dist/vue.js"></script>
+  <style>
+    .defer-visible {
+      display: none;
+    }
+  </style>
   <script>
     // localStorage test
     {
@@ -40,11 +45,13 @@
         }
       }
     }
+    setTimeout(() => document.querySelectorAll('.defer-visible').forEach(e => e.classList.remove('defer-visible')), 1000);
   </script>
 </head>
 
 <body>
-  <div id="nge-error">Oops! There was an error and Neuroglancer could not be loaded. Please follow the
+  <div id="nge-error" class='defer-visible'>Oops! There was an error and Neuroglancer could not be loaded. Please follow
+    the
     instructions in the <a
       href="https://docs.google.com/document/d/1FvEtMnAHenufDtCqKdi2DAyPyX9IzWkW9P2H31WxkMo">FAQ</a> to
     troubleshoot.


### PR DESCRIPTION
Apparently some people are still getting FOUC with the error message. This should defer it by a second although this is basically a bandaid.