### PR TITLE
Highlight unread Getting Started links

### DIFF
--- a/src/components/GettingStarted.vue
+++ b/src/components/GettingStarted.vue
@@ -10,7 +10,7 @@
         <span class="nge-gs-unread" v-show="!cheatsheetRead">⬤</span>
       </div>
       <div class="nge-gs-link">
-        <a href="https://drive.google.com/drive/u/0/folders/1SwWatyE-GLLhJrRIIuRqPBhLh5uf5C3x" target="_blank" @click="markRead('trainingRead')">Self-guided training</a>
+        <a href="https://docs.google.com/document/d/1ItdRpMybhx1ebjI41TQZDFIymfruk_GiZu4ztP6f3OM/edit" target="_blank" @click="markRead('trainingRead')">Self-guided training</a>
         <span class="nge-gs-unread" v-show="!trainingRead">⬤</span>
       </div>
       <div class="nge-gs-link">
@@ -67,7 +67,7 @@ export default Vue.extend({
   color: #fff;
 }
 .nge-gs-unread {
-  color: #19C178;
+  text-shadow: 0 0 8px;
   animation: pulse 2s infinite;
 }
 

--- a/src/components/GettingStarted.vue
+++ b/src/components/GettingStarted.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="nge-getting-started">
-    <!--div class="nge-gs-title">
-      <a href="https://flywire.ai/" target="_blank"><img src="images/logo.png" width=200 title="FlyWire"></a>
-    </div-->
     <div class="nge-gs-links">
       <div class="nge-gs-link">
-        <a href="https://drive.google.com/file/d/19qtO1U0wF4Ga9_Ruow6yHvRyZxsSG3zn/view?ts=5e822617" target="_blank">Welcome video</a>
+        <a href="https://drive.google.com/file/d/19qtO1U0wF4Ga9_Ruow6yHvRyZxsSG3zn/view?ts=5e822617" target="_blank" @click="markRead('welcomeRead')">Welcome video</a>
+        <span class="nge-gs-unread" v-show="!welcomeRead">⬤</span>
       </div>
       <div class="nge-gs-link">
-        <a href="https://docs.google.com/document/d/1tjy6axXvxVcfvrYiBbJsLTSx1Y3rTGI_HcXKETIqyiM/edit" target="_blank">Cheatsheet</a>
+        <a href="https://docs.google.com/document/d/1tjy6axXvxVcfvrYiBbJsLTSx1Y3rTGI_HcXKETIqyiM/edit" target="_blank" @click="markRead('cheatsheetRead')">Cheatsheet</a>
+        <span class="nge-gs-unread" v-show="!cheatsheetRead">⬤</span>
       </div>
       <div class="nge-gs-link">
-        <a href="https://drive.google.com/drive/u/0/folders/1SwWatyE-GLLhJrRIIuRqPBhLh5uf5C3x" target="_blank">Self-guided training</a>
+        <a href="https://drive.google.com/drive/u/0/folders/1SwWatyE-GLLhJrRIIuRqPBhLh5uf5C3x" target="_blank" @click="markRead('trainingRead')">Self-guided training</a>
+        <span class="nge-gs-unread" v-show="!trainingRead">⬤</span>
       </div>
       <div class="nge-gs-link">
         <a href="https://join.slack.com/t/flywire-forum/shared_invite/zt-d6pyjonk-uC7_kjcjU~8c64t~Qid~oQ" target="_blank">Slack Forum</a>
@@ -27,6 +27,19 @@
 import Vue from "vue";
 
 export default Vue.extend({
+  data() {
+    return {
+      welcomeRead: localStorage.getItem("welcomeRead") === "true",
+      cheatsheetRead: localStorage.getItem("cheatsheetRead") === "true",
+      trainingRead: localStorage.getItem("trainingRead") === "true"
+    }
+  },
+  methods: {
+    markRead(link: string) {
+      (<any>this)[link] = true;
+      localStorage.setItem(link, "true");
+    }
+  }
 });
 </script>
 
@@ -52,5 +65,21 @@ export default Vue.extend({
 }
 .nge-gs-link > a {
   color: #fff;
+}
+.nge-gs-unread {
+  color: #19C178;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    color: #19C178;
+  }
+  50% {
+    color: #008DB4;
+  }
+  100% {
+    color: #19C178;
+  }
 }
 </style>


### PR DESCRIPTION
Puts little glowing dots next to the Getting Started links that disappear when you click on the links.