### PR TITLE
neuroglancer's use of scrollIntoView was causing the body to scroll. …

### DIFF
--- a/src/components/Leaderboard.vue
+++ b/src/components/Leaderboard.vue
@@ -96,6 +96,7 @@ export default Vue.extend({
   background-color: #111;
   display: grid;
   grid-template-rows: min-content auto;
+  overflow: hidden; /* fixes issue with ng use of scrollIntoView */
 }
 
 .nge-leaderboard-content {


### PR DESCRIPTION
…One fix was to set overflow: hidden on the leaderboard. May be a simplebar bug.